### PR TITLE
Update state of EOS in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Share your knowledge. [Contributing guide](CONTRIBUTING.md)
 | Counterparty                           | ?              |  ?                                                          | Yes   |    
 | [Corda](https://www.corda.net/)        | ?              |
 | [DFINITY](https://dfinity.org/)        | EVM?           | Ethereum compatible (aka Solidity, Serpent, etc.)                                           | No |  |  |   |  |
-| [EOS](https://eos.io/)                 | EVM / eWASM    |  C/C++ (compiles to WASM)                                   | no    |    
+| [EOS](https://eos.io/)                 | EVM / eWASM    |  C/C++ (compiles to WASM)                                   | Yes    |    
 | [Ethereum](https://www.ethereum.org/)  | EVM            |  Solidity                                                   | Yes   | CA    |Switzerland  |2014.04|2015.07   |
 | [Ethereum Classic](https://ethereumclassic.github.io/)| EVM |  Solidity                                              | Yes   | ^^^   | no          | ^^^   | ^^^      |
 | [Exonum](https://exonum.com)           | ?              |  Rust. Java bindings TBD                                    | No    | UA    |Netherlands  |       |2017.07   |


### PR DESCRIPTION
As of 15 June 2018 the EOS MainNet is live and activated, smart contracts have been deployed since.

See for example https://steemit.com/cryptocurrency/@mix1009/eos-mainnet-activated